### PR TITLE
ISSUE-7: Ability to use depth in the custom deep function (fix #7)

### DIFF
--- a/lib/directory-reader.js
+++ b/lib/directory-reader.js
@@ -176,6 +176,9 @@ DirectoryReader.prototype.processItem = function processItem (dir, item, done) {
     // (i.e. options.basePath and options.sep)
     stats.path = itemPath;
 
+    // Add depth of the path to the fs.Stats object for use this in the filter function
+    stats.depth = dir.depth;
+
     if (reader.shouldRecurse(stats, posixPath, maxDepthReached)) {
       // Add this subdirectory to the queue
       reader.queue.push({

--- a/test/specs/deep.js
+++ b/test/specs/deep.js
@@ -174,6 +174,32 @@ describe('options.deep', function () {
       }
     },
     {
+      it: 'should recurse based on a custom function with depth property',
+      args: ['test/dir', {
+        deep: function (stats) {
+          return stats.depth !== 1;
+        },
+      }],
+      assert: function (error, data) {
+        expect(error).to.be.null;
+        expect(data).to.have.same.members(this.omitSubdir(dir.deep.data));
+      },
+      streamAssert: function (errors, data, files, dirs, symlinks) {
+        expect(errors.length).to.equal(0);
+        expect(data).to.have.same.members(this.omitSubdir(dir.deep.data));
+        expect(files).to.have.same.members(this.omitSubdir(dir.deep.files));
+        expect(dirs).to.have.same.members(this.omitSubdir(dir.deep.dirs));
+        expect(symlinks).to.have.same.members(this.omitSubdir(dir.deep.symlinks));
+      },
+
+      // Omits the contents of the "subdir" directory
+      omitSubdir: function (paths) {
+        return paths.filter(function (p) {
+          return p.split(path.sep).length <= 2;
+        });
+      }
+    },
+    {
       it: 'should return all deep contents if custom deep function always returns true',
       args: ['test/dir', {
         deep: function () {


### PR DESCRIPTION
### Links

  * https://github.com/BigstickCarpet/readdir-enhanced/issues/7

### What is this?

  * Add depth of the path to the `fs.Stats` object for use this in the filter function.